### PR TITLE
Add sparse parity task

### DIFF
--- a/configs/trial.yaml
+++ b/configs/trial.yaml
@@ -13,10 +13,16 @@ optim:
 
 data: 
   task: sparse_parity
+  task_params:
+    n_tasks: 4
+    k: 5
+    n: 40
   
 train:
   seed: 42
   device: "cuda:0"
+  batch_size: 64
+  train_frac: 0.6
   train_iters: 500
   eval_iters: 50
   eval_every: 50

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     py_modules=["toy_scaling"],
     version="0.0.1",
     description="",
-    author="",
+    author="Hailey Schoelkopf and Zhangir Azerbayev",
     packages=find_packages(),
     install_requires=[
         str(r)

--- a/toy_scaling/data/sparse_parity.py
+++ b/toy_scaling/data/sparse_parity.py
@@ -1,0 +1,86 @@
+import torch
+import numpy as np
+
+from tqdm import tqdm
+
+# TODO: turn this into a subclass of a general ToyDataset class?
+class SparseParityDataset(torch.utils.data.Dataset):
+
+    """
+    The sparse parity task.
+    for more information on this task, 
+    please see https://arxiv.org/abs/2207.08799 or 
+    https://arxiv.org/abs/2303.13506 .
+
+    In particular, we implement the formulation from Michaud et al.
+    To use the version more closely following (n,k) sparse parity in Barak et al. 
+    please use `n_tasks=1`, `n=n`, `k=k`.
+    """
+
+    def __init__(
+        self,
+        config, 
+        n_samples,
+        np_rng,
+    ):
+
+        self.config = config
+        self.n_samples = n_samples
+        self.np_rng = np_rng
+
+        self.construct_samples()
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        return self.samples[idx]
+
+    def construct_samples(self):
+
+        # validate the task-specific hyperparameters
+        hparams = self.config.data.task_params
+
+        n_tasks = hparams.get("n_tasks", 1)
+        n = hparams.get("n", 8)
+        k = hparams.get("k", 2)
+        task_freqs = hparams.get("task_freqs", n_tasks * [1.0])
+        task_freqs = [prob / sum(task_freqs) for prob in task_freqs] # normalize sum of subtask probs to 1
+
+        assert n_tasks * k <= n, \
+        "n_tasks * k must not exceed n for sparse parity task!"
+        assert len(task_freqs) == n_tasks, "if passing individual subtask frequencies, must have same length as num. subtasks"
+
+        # determine k relevant bits for each subtask (non-overlapping size k subsets). 
+        self.active_indices = np.split(self.np_rng.choice(n, n_tasks * k, replace=False), n_tasks)
+        # self.task_bits[i] gives np.array of the k (non-control bit) indices to consider for i-th subtask!
+
+
+        self.samples = []
+        # gen samples. 
+        # TODO: add a name to progress bar
+        for i in tqdm(range(self.n_samples)):
+            
+            # select a subtask, with probability task_freqs[i] for each task
+            active_task = self.np_rng.choice(n_tasks, p=task_freqs)
+            
+            ctrl_bits = np.zeros(n_tasks)
+            ctrl_bits[active_task] = 1
+
+            # draw a string of n 0's and 1's, with uniform freq.
+            task_bits = self.np_rng.choice(2, n)
+
+            # sum the active task bits. 
+            bitsum = task_bits[self.active_indices[active_task]].sum()
+
+            label = bitsum % 2
+
+            sample = {
+                "inputs": torch.Tensor(np.concatenate([ctrl_bits, task_bits])),
+                "labels": torch.Tensor([label]),
+                "ctrl_bits": torch.Tensor(ctrl_bits),
+                "task_bits": torch.Tensor(task_bits),
+                "active_task": torch.Tensor([active_task]),
+                "active_indices": torch.Tensor(self.active_indices[active_task]) 
+            }
+            self.samples.append(sample)

--- a/toy_scaling/utils.py
+++ b/toy_scaling/utils.py
@@ -1,5 +1,5 @@
 import torch
-import np
+import numpy as np
 import random
 
 


### PR DESCRIPTION
This PR adds the `(n,k)` and `(n_{tasks}, n, k)` sparse parity problem as discussed and used in Barak et al. 2022 (https://arxiv.org/abs/2207.08799) and Michaud et al. 2022 (https://arxiv.org/abs/2303.13506) .

Not yet implemented in this PR is to set particular task frequency curves of note, such as a power law distribution. We may also want to enable weighting subtasks by "importance" in the CE loss as in "Toy Models of Superposition".